### PR TITLE
Fix incorrect `:git/uri` key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ more explicit and extensible lifecycle for components.
 Cljfx uses `tools.deps`, so you can add this repo with latest sha as a 
 dependency:
 ```edn
- {cljfx {:git/uri "https://github.com/cljfx/cljfx" :sha "<insert-sha-here>"}}
+ {cljfx {:git/url "https://github.com/cljfx/cljfx" :sha "<insert-sha-here>"}}
 ```
 Cljfx is also published on clojars, so you can add `cljfx` as a maven
 dependency, current version is on this badge: [![Clojars Project](https://img.shields.io/clojars/v/cljfx.svg?logo=clojure&logoColor=white)](https://clojars.org/cljfx)


### PR DESCRIPTION
Should be `:git/url`. Leads to an opaque classpath error if you paste it in, spent more time tracking it down than I care to admit ;P