### PR TITLE
Support declarative event filters

### DIFF
--- a/examples/devtools.css
+++ b/examples/devtools.css
@@ -1,0 +1,3 @@
+.mouse-over-highlight {
+  -fx-background-color: pink;
+}

--- a/examples/e30_devtools_via_event_filters.clj
+++ b/examples/e30_devtools_via_event_filters.clj
@@ -1,0 +1,115 @@
+; Author: Ambrose Bonnaire-Sergeant
+(ns e30-devtools-via-event-filters
+  (:require [cljfx.api :as fx]
+            [cljfx.ext.node :as fx.ext.node])
+  (:import [javafx.scene.input MouseEvent]
+           [javafx.scene Node]
+           [javafx.event Event]))
+
+;; Setting an event filter on a node allows that node to
+;; intercept events intended for its children.
+;; 
+;; Add `:event-filter` to any Node
+;; to register a catch-all event filter.
+;;
+;; This example highlights hovered nodes by
+;; setting an event filter on the root node that intercepts
+;; MouseEvent's sent to inner nodes.
+
+(set! *warn-on-reflection* true)
+
+(def *context
+  (atom (fx/create-context
+          {:current-node nil})))
+
+; [(U nil Node) Event CSSClass -> (U nil node)]
+(defn devtools-highlight-filter
+  "Takes the previously highlighted node (or nil), 
+  an Event (via event filter), and the CSS class
+  to apply to highlighted nodes.
+
+  Returns the current highlighted node (or nil)
+  after highlighting it (and removing highlighting
+  on the previous node)."
+  [^Node hovered-node ^Event event css-class]
+  {:pre [(string? css-class)]}
+  (when (instance? MouseEvent event)
+    (let [^Node target (.getTarget event)
+          event-type (.getEventType event)]
+      (when (instance? Node target)
+        (if (#{MouseEvent/MOUSE_EXITED
+               MouseEvent/MOUSE_EXITED_TARGET}
+              event-type)
+          (let [_ (-> target .getStyleClass (.remove css-class))]
+            (when (not= hovered-node target)
+              hovered-node))
+          (let [_ (when (and hovered-node (not= hovered-node target))
+                    (-> hovered-node .getStyleClass (.remove css-class)))
+                _ (when (not= hovered-node target)
+                    (when-not (-> target .getStyleClass (.contains css-class))
+                      (-> target .getStyleClass (.add css-class))))]
+            target))))))
+
+(def mouse-over-css-class "mouse-over-highlight")
+
+(defmulti handle-event :event/type)
+(defmethod handle-event ::on-event-filter [{:keys [fx/context fx/event]}]
+  {:context (fx/swap-context context update :current-node
+                             devtools-highlight-filter
+                             event
+                             mouse-over-css-class)})
+
+(defn root-view [{:keys [fx/context]}]
+  {:fx/type :stage
+   :showing true
+   :width 600
+   :height 500
+   :scene {:fx/type :scene
+           :stylesheets #{"devtools.css"}
+           :root
+           {:fx/type :v-box
+            ;; add an event filter to the root node
+            :event-filter {:event/type ::on-event-filter
+                           ; because we are changing observable lists in
+                           ; the event handler
+                           :fx/sync true}
+            ;; the UI
+            :children
+            [{:fx/type :label
+              :text (str "Current node: " (some-> (fx/sub context :current-node)
+                                                  class
+                                                  .getSimpleName))}
+             {:fx/type :label
+              :text (str "Has CSS classes: " (some-> ^Node (fx/sub context :current-node)
+                                                     .getStyleClass
+                                                     vec))}
+             ; mouse over these nodes to highlight them
+             {:fx/type :split-pane
+              :divider-positions [0.5]
+              :items [{:fx/type :v-box
+                       :padding 50
+                       :children [{:fx/type :split-pane
+                                   :divider-positions [0.5]
+                                   :items [{:fx/type :v-box
+                                            :padding 50
+                                            :children [{:fx/type :h-box
+                                                        :children [{:fx/type :label
+                                                                    :text "left 1"}]}
+                                                       {:fx/type :label
+                                                        :text "left 2"}]}
+                                           {:fx/type :h-box
+                                            :padding 50
+                                            :children [{:fx/type :label
+                                                        :text "right"}]}]}
+                                  {:fx/type :label
+                                   :text "left 2"}]}
+                      {:fx/type :h-box
+                       :padding 50
+                       :children [{:fx/type :label
+                                   :text "right"}]}]}]}}})
+
+(def app
+  (fx/create-app *context
+    :event-handler handle-event
+    :desc-fn (fn [_]
+               {:fx/type root-view})))

--- a/src/cljfx/fx/node.clj
+++ b/src/cljfx/fx/node.clj
@@ -2,8 +2,11 @@
   "Part of a public API"
   (:require [cljfx.composite :as composite]
             [cljfx.lifecycle :as lifecycle]
-            [cljfx.coerce :as coerce])
-  (:import [javafx.scene Node AccessibleRole CacheHint DepthTest]
+            [cljfx.coerce :as coerce]
+            [cljfx.prop :as prop]
+            [cljfx.mutator :as mutator])
+  (:import [javafx.event Event EventHandler]
+           [javafx.scene Node AccessibleRole CacheHint DepthTest]
            [javafx.scene.effect BlendMode]
            [javafx.geometry NodeOrientation]))
 
@@ -24,6 +27,12 @@
     :disable [:setter lifecycle/scalar :default false]
     :effect [:setter lifecycle/dynamic]
     :event-dispatcher [:setter lifecycle/scalar]
+    ; takes an event description that receives filtered Events with event type Event/ANY
+    :event-filter [(mutator/adder-remover
+                     #(.addEventFilter ^Node %1 Event/ANY ^EventHandler %2)
+                     #(.removeEventFilter ^Node %1 Event/ANY ^EventHandler %2))
+                   lifecycle/event-handler
+                   :coerce coerce/event-handler]
     :focus-traversable [:setter lifecycle/scalar :default false]
     :id [:setter lifecycle/scalar]
     :input-method-requests [:setter lifecycle/scalar]


### PR DESCRIPTION
Adds extension lifecycle `cljfx.ext.node/with-event-filter-props` to declaratively specify event filters.

Fixes #2