### PR TITLE
use correct lifecycle for :selected-item prop

### DIFF
--- a/src/cljfx/ext/selection_model.clj
+++ b/src/cljfx/ext/selection_model.clj
@@ -24,7 +24,7 @@
     (mutator/setter #(doto ^SelectionModel (get-model %1)
                        (.clearSelection)
                        (.select ^Object %2)))
-    lifecycle/scalar))
+    lifecycle/dynamic))
 
 (defn on-selected-item-changed-prop [get-model]
   (prop/make


### PR DESCRIPTION
Enables support for node descriptions in :selected-item, as alluded to by the docs
(see cljfx.ext.{tab-pane,tree-view}).