### PR TITLE
allow descriptions in some :selected-item lifecycles

### DIFF
--- a/examples/e27_selection_models.clj
+++ b/examples/e27_selection_models.clj
@@ -1,34 +1,113 @@
 (ns e27-selection-models
   (:require [cljfx.api :as fx]
             [cljfx.ext.list-view :as fx.ext.list-view]
+            [cljfx.ext.tab-pane :as fx.ext.tab-pane]
             [cljfx.ext.table-view :as fx.ext.table-view]
             [cljfx.ext.tree-view :as fx.ext.tree-view])
-  (:import [javafx.scene.control TreeItem]))
+  (:import [javafx.scene.control Tab TreeItem]))
 
-(def *state
-  (atom {:selection ["/etc"
-                     "/users/vlaaad/.clojure"]
-         :tree {"dev" {}
-                "etc" {}
-                "users" {"vlaaad" {".clojure" {"deps.edn" {}}}}
-                "usr" {"bin" {}
-                       "lib" {}}}}))
+(set! *warn-on-reflection* true)
 
-(defn list-view [{:keys [items selection]}]
+(defn init-state []
+  {:selection ["/etc"
+               "/users/vlaaad/.clojure"]
+   :tree {"dev" {}
+          "etc" {}
+          "users" {"vlaaad" {".clojure" {"deps.edn" {}}}}
+          "usr" {"bin" {}
+                 "lib" {}}}})
+
+(declare *state renderer)
+
+; clean up renderer on file reload
+(when (and (.hasRoot #'*state)
+           (.hasRoot #'renderer))
+  (fx/unmount-renderer *state renderer)
+  (reset! *state (init-state)))
+
+(defonce *state
+  (atom (init-state)))
+
+(defn list-view [{:keys [items selection selection-mode]}]
   {:fx/type fx.ext.list-view/with-selection-props
-   :props {:selection-mode :multiple
-           :selected-items selection
-           :on-selected-items-changed {:event/type ::select}}
+   :props (case selection-mode
+            :multiple {:selection-mode :multiple
+                       :selected-items selection
+                       :on-selected-items-changed {:event/type ::select-multiple}}
+            :single (cond-> {:selection-mode :single
+                             :on-selected-item-changed {:event/type ::select-single}}
+                      (seq selection)
+                      (assoc :selected-item (-> selection sort first))))
    :desc {:fx/type :list-view
           :cell-factory (fn [path]
                           {:text path})
           :items items}})
 
-(defn table-view [{:keys [path->value selection]}]
+(defn- let-refs [refs desc]
+  {:fx/type fx/ext-let-refs
+   :refs refs
+   :desc desc})
+
+(defn- get-ref [ref]
+  {:fx/type fx/ext-get-ref
+   :ref ref})
+
+(defn- with-tab-selection-props [props desc]
+  {:fx/type fx.ext.tab-pane/with-selection-props
+   :props props
+   :desc desc})
+
+; Programatically setting tabs is somewhat buggy in JavaFX, so for
+; demonstration purposes :selection-capabilities controls the selection model:
+; - #{:read} the tab changes just based on the current state
+; - #{:write} the tab changes just based the user selection (eg. clicking)
+; - #{:read :write} both of the above (quite buggy, multiple tabs seem selected
+;   and the content of tabs blend together)
+
+(defn tab-pane [{:keys [items selection selection-capabilities]}]
+  {:pre [(set? selection-capabilities)]}
+  (let [selected-tab-id (-> selection sort first)
+        _ (assert selected-tab-id)]
+    (let-refs (into {}
+                    (map (fn [item]
+                           {:pre [(string? item)]}
+                           [item
+                            (merge
+                              {:fx/type :tab
+                               :graphic {:fx/type :label
+                                         :text item}
+                               :id item
+                               :closable false}
+                              (cond-> {}
+                                ; buggy for :read'ing tabs
+                                (:write selection-capabilities)
+                                (assoc :content {:fx/type :label
+                                                 :text item})
+
+                                (not (:write selection-capabilities))
+                                (assoc :disable (if selected-tab-id
+                                                  (not= item selected-tab-id)
+                                                  true))))]))
+                    items)
+      (with-tab-selection-props
+        (cond-> {}
+          (:read selection-capabilities) (assoc :selected-item (get-ref selected-tab-id))
+          (:write selection-capabilities) (assoc :on-selected-item-changed {:event/type ::select-tab}))
+        {:fx/type :tab-pane
+         :tabs (map #(-> (get-ref %)
+                         (assoc :fx/id %))
+                    items)}))))
+
+(defn table-view [{:keys [path->value selection selection-mode]}]
   {:fx/type fx.ext.table-view/with-selection-props
-   :props {:selection-mode :multiple
-           :selected-items selection
-           :on-selected-items-changed {:event/type ::select}}
+   :props (case selection-mode
+            :multiple {:selection-mode :multiple
+                       :selected-items selection
+                       :on-selected-items-changed {:event/type ::select-multiple}}
+            :single (cond-> {:selection-mode :single
+                             :on-selected-item-changed {:event/type ::select-single}}
+                      (seq selection)
+                      (assoc :selected-item (-> selection sort first))))
    :desc {:fx/type :table-view
           :columns [{:fx/type :table-column
                      :text "path"
@@ -74,15 +153,21 @@
                       new-desc children)))]
     (f tree "" desc)))
 
-(defn tree-view [{:keys [tree selection]}]
+(defn tree-view [{:keys [tree selection selection-mode]}]
   (make-tree-item-refs
     tree
     {:fx/type fx.ext.tree-view/with-selection-props
-     :props {:selection-mode :multiple
-             :selected-items (for [x selection]
-                               {:fx/type fx/ext-get-ref
-                                :ref x})
-             :on-selected-items-changed {:event/type ::select-tree-items}}
+     :props (case selection-mode
+              :multiple {:selection-mode :multiple
+                         :selected-items (for [x selection]
+                                           {:fx/type fx/ext-get-ref
+                                            :ref x})
+                         :on-selected-items-changed {:event/type ::select-tree-items}}
+              :single (cond-> {:selection-mode :single
+                               :on-selected-item-changed {:event/type ::select-tree-item}}
+                        (seq selection)
+                        (assoc :selected-item {:fx/type fx/ext-get-ref
+                                               :ref (-> selection sort first)})))
      :desc {:fx/type :tree-view
             :show-root false
             :root {:fx/type :tree-item
@@ -101,34 +186,108 @@
     (into (sorted-map)
           (flatten-map "" tree))))
 
+(defn add-header [title desc]
+  {:fx/type :v-box
+   :spacing 10
+   :children [{:fx/type :label
+               :text title}
+              desc]})
+
+(defn on-grid [{:keys [rows columns descs]}]
+  {:pre [(vector? descs)
+         (<= (count descs)
+             (* rows columns))]}
+  {:fx/type :grid-pane
+   :row-constraints (repeat rows {:fx/type :row-constraints
+                                  :percent-height (/ 100 rows)})
+   :column-constraints (repeat columns {:fx/type :column-constraints
+                                        :percent-width (/ 100 columns)})
+   :children (for [row (range rows)
+                   col (range columns)
+                   :let [loc (+ (* row rows) col)]
+                   :when (< loc (count descs))]
+               (-> (nth descs loc)
+                   (assoc :grid-pane/row row
+                          :grid-pane/column col)))})
+
 (defn view [{{:keys [tree selection]} :state}]
   (let [path->value (make-path->value tree)]
     {:fx/type :stage
      :showing true
      :width 960
      :scene {:fx/type :scene
-             :root {:fx/type :grid-pane
-                    :column-constraints [{:fx/type :column-constraints
-                                          :percent-width 100/3}
-                                         {:fx/type :column-constraints
-                                          :percent-width 100/3}
-                                         {:fx/type :column-constraints
-                                          :percent-width 100/3}]
-                    :children [{:fx/type list-view
-                                :grid-pane/column 0
+             :root {:fx/type :scroll-pane
+                    :fit-to-width true
+                    :fit-to-height true
+                    :content
+                    {:fx/type on-grid
+                     :rows 3
+                     :columns 3
+                     :descs [(add-header
+                               ":list-view :multiple"
+                               {:fx/type list-view
                                 :items (keys path->value)
-                                :selection selection}
+                                :selection-mode :multiple
+                                :selection selection})
+                             (add-header
+                               ":list-view :single"
+                               {:fx/type list-view
+                                :items (keys path->value)
+                                :selection-mode :single
+                                :selection selection})
+                             (add-header
+                               ":table-view :multiple"
                                {:fx/type table-view
-                                :grid-pane/column 1
                                 :path->value path->value
-                                :selection selection}
+                                :selection-mode :multiple
+                                :selection selection})
+                             (add-header
+                               ":table-view :single"
+                               {:fx/type table-view
+                                :path->value path->value
+                                :selection-mode :single
+                                :selection selection})
+                             (add-header
+                               ":tree-view :multiple"
                                {:fx/type tree-view
-                                :grid-pane/column 2
                                 :tree tree
-                                :selection selection}]}}}))
+                                :selection-mode :multiple
+                                :selection selection})
+                             (add-header
+                               ":tree-view :single"
+                               {:fx/type tree-view
+                                :tree tree
+                                :selection-mode :single
+                                :selection selection})
+                             (add-header
+                               ":tab-pane (opens current selection)"
+                               {:fx/type tab-pane
+                                :items (keys path->value)
+                                :selection-capabilities #{:read}
+                                :selection selection})
+                             (add-header
+                               ":tab-pane (only changes on click)"
+                               {:fx/type tab-pane
+                                :items (keys path->value)
+                                :selection-capabilities #{:write}
+                                :selection selection})
+                             ; buggy, content from different tabs
+                             ; blend into eachother
+                             #_
+                             (add-header
+                               ":tab-pane (read+write)"
+                               {:fx/type tab-pane
+                                :items (keys path->value)
+                                :selection-capabilities #{:read :write}
+                                :selection selection})
+                             ]}}}}))
 
 (defn tree-item-value [^TreeItem x]
   (.getValue x))
+
+(defn tab-id [^Tab x]
+  {:post [(string? %)]}
+  (.getId x))
 
 (def renderer
   (fx/create-renderer
@@ -139,8 +298,16 @@
            #(case (:event/type %)
               ::select-tree-items
               (swap! *state assoc :selection (->> % :fx/event (mapv tree-item-value)))
+              ::select-tree-item
+              (swap! *state assoc :selection (->> % :fx/event tree-item-value vector))
 
-              ::select
-              (swap! *state assoc :selection (:fx/event %)))}))
+              ::select-multiple
+              (swap! *state assoc :selection (:fx/event %))
+              ::select-single
+              (swap! *state assoc :selection (-> (:fx/event %) vector))
+
+              ::select-tab
+              (swap! *state assoc :selection (->> % :fx/event tab-id vector))
+              )}))
 
 (fx/mount-renderer *state renderer)

--- a/src/cljfx/ext/multiple_selection_model.clj
+++ b/src/cljfx/ext/multiple_selection_model.clj
@@ -58,13 +58,16 @@
         (lifecycle/make-ext-with-props props-config)
         (lifecycle/wrap-map-desc lift-ext-props keys))))
 
-(defn make-with-props [lifecycle get-model items-lifecycle default-mode]
-  (-> lifecycle
-      (ext.selection-model/make-with-props get-model)
-      (add-ext-flat-props
-        {:selection-mode (selection-mode-prop get-model default-mode)})
-      (add-ext-flat-props
-        {:selected-indices (selected-indices-prop get-model)
-         :selected-items (selected-items-prop get-model items-lifecycle)
-         :on-selected-indices-changed (on-selected-indices-changed-prop get-model)
-         :on-selected-items-changed (on-selected-items-changed-prop get-model)})))
+(defn make-with-props
+  ([lifecycle get-model items-lifecycle default-mode]
+   (make-with-props lifecycle get-model lifecycle/scalar items-lifecycle default-mode))
+  ([lifecycle get-model item-lifecycle items-lifecycle default-mode]
+   (-> lifecycle
+       (ext.selection-model/make-with-props get-model item-lifecycle)
+       (add-ext-flat-props
+         {:selection-mode (selection-mode-prop get-model default-mode)})
+       (add-ext-flat-props
+         {:selected-indices (selected-indices-prop get-model)
+          :selected-items (selected-items-prop get-model items-lifecycle)
+          :on-selected-indices-changed (on-selected-indices-changed-prop get-model)
+          :on-selected-items-changed (on-selected-items-changed-prop get-model)}))))

--- a/src/cljfx/ext/selection_model.clj
+++ b/src/cljfx/ext/selection_model.clj
@@ -19,12 +19,14 @@
          ^SelectionModel (get-model %)))
     lifecycle/change-listener))
 
-(defn selected-item-prop [get-model]
-  (prop/make
-    (mutator/setter #(doto ^SelectionModel (get-model %1)
-                       (.clearSelection)
-                       (.select ^Object %2)))
-    lifecycle/scalar))
+(defn selected-item-prop
+  ([get-model] (selected-item-prop get-model lifecycle/scalar))
+  ([get-model item-lifecycle]
+   (prop/make
+     (mutator/setter #(doto ^SelectionModel (get-model %1)
+                        (.clearSelection)
+                        (.select ^Object %2)))
+     item-lifecycle)))
 
 (defn on-selected-item-changed-prop [get-model]
   (prop/make
@@ -32,10 +34,12 @@
       #(.selectedItemProperty ^SelectionModel (get-model %)))
     lifecycle/change-listener))
 
-(defn make-with-props [lifecycle get-model]
-  (lifecycle/make-ext-with-props
-    lifecycle
-    {:selected-index (selected-index-prop get-model)
-     :on-selected-index-changed (on-selected-index-changed-prop get-model)
-     :selected-item (selected-item-prop get-model)
-     :on-selected-item-changed (on-selected-item-changed-prop get-model)}))
+(defn make-with-props 
+  ([lifecycle get-model] (make-with-props lifecycle get-model lifecycle/scalar))
+  ([lifecycle get-model item-lifecycle]
+   (lifecycle/make-ext-with-props
+     lifecycle
+     {:selected-index (selected-index-prop get-model)
+      :on-selected-index-changed (on-selected-index-changed-prop get-model)
+      :selected-item (selected-item-prop get-model item-lifecycle)
+      :on-selected-item-changed (on-selected-item-changed-prop get-model)})))

--- a/src/cljfx/ext/tab_pane.clj
+++ b/src/cljfx/ext/tab_pane.clj
@@ -1,7 +1,7 @@
 (ns cljfx.ext.tab-pane
   (:require [cljfx.lifecycle :as lifecycle]
             [cljfx.ext.selection-model :as ext.selection-model])
-  (:import [javafx.scene.control TabPane]))
+  (:import [javafx.scene.control TabPane Tab]))
 
 (def with-selection-props
   "Extension lifecycle providing selection-related props to tab-pane component
@@ -11,9 +11,14 @@
   - `:props` (optional) - map of selection-related props:
     - selection, one of:
       - `:selected-index` - int
-      - `:selected-item` - description of a tab whose instance should also be present
-        in tabs list of this TabPane
+      - `:selected-item` - a Tab, otherwise a tab description, whose instance should be present
+        in the tabs list of this TabPane
     - selection change listener, one of:
       - `:on-selected-index-changed` - will receive int
       - `:on-selected-item-changed` - will receive selected Tab"
-  (ext.selection-model/make-with-props lifecycle/dynamic #(.getSelectionModel ^TabPane %)))
+  (ext.selection-model/make-with-props
+    lifecycle/dynamic
+    #(.getSelectionModel ^TabPane %)
+    (lifecycle/if-desc #(instance? Tab %)
+      lifecycle/scalar
+      lifecycle/dynamic)))

--- a/src/cljfx/ext/tree_table_view.clj
+++ b/src/cljfx/ext/tree_table_view.clj
@@ -1,7 +1,7 @@
 (ns cljfx.ext.tree-table-view
   (:require [cljfx.ext.multiple-selection-model :as ext.multiple-selection-model]
             [cljfx.lifecycle :as lifecycle])
-  (:import [javafx.scene.control TreeTableView]))
+  (:import [javafx.scene.control TreeTableView TreeItem]))
 
 (def with-selection-props
   "Extension lifecycle providing selection-related props to tree-table-view component
@@ -12,7 +12,7 @@
     - `:selection-mode` - either `:single` or `:multiple`
     - selection, one of:
       - `:selected-index` - int
-      - `:selected-item` - description of a tree item
+      - `:selected-item` - a TreeItem, otherwise a tree item description
       - `:selected-indices` - coll of ints, prefer this when selection mode is `:multiple`
       - `:selected-items` - coll of descriptions of tree items, prefer this when selection
         mode is `:multiple`
@@ -24,5 +24,8 @@
   (ext.multiple-selection-model/make-with-props
     lifecycle/dynamic
     #(.getSelectionModel ^TreeTableView %)
+    (lifecycle/if-desc #(instance? TreeItem %)
+      lifecycle/scalar
+      lifecycle/dynamic)
     lifecycle/dynamics
     :single))

--- a/src/cljfx/ext/tree_view.clj
+++ b/src/cljfx/ext/tree_view.clj
@@ -1,7 +1,7 @@
 (ns cljfx.ext.tree-view
   (:require [cljfx.lifecycle :as lifecycle]
             [cljfx.ext.multiple-selection-model :as ext.multiple-selection-model])
-  (:import [javafx.scene.control TreeView]))
+  (:import [javafx.scene.control TreeView TreeItem]))
 
 (def with-selection-props
   "Extension lifecycle providing selection-related props to tree-view component
@@ -12,7 +12,7 @@
     - `:selection-mode` - either `:single` or `:multiple`
     - selection, one of:
       - `:selected-index` - int
-      - `:selected-item` - description of a tree item
+      - `:selected-item` - a TreeItem, otherwise a tree item description
       - `:selected-indices` - coll of ints, prefer this when selection mode is `:multiple`
       - `:selected-items` - coll of descriptions of tree items, prefer this when selection
         mode is `:multiple`
@@ -24,5 +24,8 @@
   (ext.multiple-selection-model/make-with-props
     lifecycle/dynamic
     #(.getSelectionModel ^TreeView %)
+    (lifecycle/if-desc #(instance? TreeItem %)
+      lifecycle/scalar
+      lifecycle/dynamic)
     lifecycle/dynamics
     :single))


### PR DESCRIPTION
Adds support for descriptions in `:selected-item` for list-view, tab-pane, tree-table-view, and tree-view.

Uses the approach discussed in #27. I extended `e27-selection-models` to test all kinds of selection models.