### PR TITLE
Add Transitions with :indefinite examples

### DIFF
--- a/examples/e31_indefinite_transitions.clj
+++ b/examples/e31_indefinite_transitions.clj
@@ -14,19 +14,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn init-state []
-  {})
-
-(declare *state renderer)
-
-(when (and (.hasRoot #'*state)
-           (.hasRoot #'renderer))
-  (fx/unmount-renderer *state renderer)
-  (reset! *state (init-state)))
-
-(def *state
-  (atom (init-state)))
-
 (defn- let-refs [refs desc]
   {:fx/type fx/ext-let-refs
    :refs refs
@@ -149,7 +136,7 @@
                    :radius 35}
             :duration [1 :s]
             :interpolator :linear
-            :orientation :orthogonal-to-tanget
+            :orientation :orthogonal-to-tangent
             :cycle-count :indefinite}]
    ["Parallel" {:fx/type :parallel-transition
                 :auto-reverse true
@@ -239,6 +226,25 @@
                                           :height 50}}))
                               indefinite-animations)}}})
 
+(fx/on-fx-thread
+  (fx/create-component
+    {:fx/type view}))
+
+; how to add state
+(comment
+(defn init-state []
+  {})
+
+(declare *state renderer)
+
+(when (and (.hasRoot #'*state)
+           (.hasRoot #'renderer))
+  (fx/unmount-renderer *state renderer)
+  (reset! *state (init-state)))
+
+(def *state
+  (atom (init-state)))
+
 (def renderer
   (fx/create-renderer
     :middleware (fx/wrap-map-desc (fn [state]
@@ -246,3 +252,4 @@
                                      :state state}))))
 
 (fx/mount-renderer *state renderer)
+)

--- a/examples/e31_indefinite_transitions.clj
+++ b/examples/e31_indefinite_transitions.clj
@@ -1,0 +1,248 @@
+; Author: Ambrose Bonnaire-Sergeant
+(ns e31-indefinite-transitions
+  (:require [cljfx.api :as fx]))
+
+;; A transition is a kind of animation in JavaFX which
+;; usually operates on nodes. This file demonstrates
+;; how to start transitions that run forever (by setting
+;; :cycle-count to :indefinite) and attach them to arbitrary
+;; nodes.
+
+;; The logic to attach a transition to a node is in
+;; [[start-transition-on]], and the actual definitions for
+;; the animations in this file are [[indefinite-animations]].
+
+(set! *warn-on-reflection* true)
+
+(defn init-state []
+  {})
+
+(declare *state renderer)
+
+(when (and (.hasRoot #'*state)
+           (.hasRoot #'renderer))
+  (fx/unmount-renderer *state renderer)
+  (reset! *state (init-state)))
+
+(def *state
+  (atom (init-state)))
+
+(defn- let-refs [refs desc]
+  {:fx/type fx/ext-let-refs
+   :refs refs
+   :desc desc})
+
+(defn- get-ref [ref]
+  {:fx/type fx/ext-get-ref
+   :ref ref})
+
+(def transition-target-prop
+  "For transitions that target a node this map specifies
+  the prop to write to. eg., :fade-transition takes :node prop,
+  but :fill-transition takes a :shape prop."
+  (into {}
+        (concat (map vector
+                     #{:fade-transition     
+                       :scale-transition    
+                       :rotate-transition   
+                       :path-transition     
+                       :translate-transition
+                       :parallel-transition
+                       :sequential-transition}
+                     (repeat :node))
+                (map vector
+                     #{:fill-transition
+                       :stroke-transition}
+                     (repeat :shape)))))
+
+(defn add-target-prop [desc node]
+  (let [target-prop (get transition-target-prop (:fx/type desc))]
+    (cond-> desc
+      target-prop (assoc target-prop node))))
+
+(defn start-transition-on
+  "Returns the given desc the given transition animation attached
+  and running."
+  [{:keys [desc transition]}]
+  (let-refs {::transition-node desc}
+    (let [tn (get-ref ::transition-node)]
+      (let-refs {::transition (-> transition
+                                  (add-target-prop tn)
+                                  (assoc :status :running))}
+        tn))))
+
+(defn on-grid [{:keys [rows columns children]}]
+  {:pre [(vector? children)
+         (<= (count children)
+             (* rows columns))]}
+  {:fx/type :grid-pane
+   :row-constraints (repeat rows {:fx/type :row-constraints
+                                  :percent-height (/ 100 rows)})
+   :column-constraints (repeat columns {:fx/type :column-constraints
+                                        :percent-width (/ 100 columns)})
+   :children (let [loc (atom -1)]
+               (vec
+                 (for [row (range rows)
+                       col (range columns)
+                       :let [_ (swap! loc inc)]
+                       :when (< @loc (count children))]
+                   (-> (nth children @loc)
+                       (assoc :grid-pane/row row
+                              :grid-pane/column col)))))})
+
+(defn with-header [text desc]
+  {:fx/type :grid-pane
+   :row-constraints (repeat 1 {:fx/type :row-constraints
+                               :percent-height 100/1})
+   :column-constraints (repeat 2 {:fx/type :column-constraints
+                                  :percent-width 100/2})
+   :children [{:fx/type :label
+               :grid-pane/row 0
+               :grid-pane/column 0
+               :text text}
+              (assoc desc
+                     :grid-pane/row 0
+                     :grid-pane/column 1)]})
+
+; The animations
+(def indefinite-animations
+  [["Fade" {:fx/type :fade-transition
+            :from-value 1.0
+            :to-value 0.3
+            :cycle-count :indefinite
+            :duration [1 :s]
+            :auto-reverse true}]
+   ["Fill" {:fx/type :fill-transition
+            :from-value :green
+            :to-value :red
+            :cycle-count :indefinite
+            :duration [1 :s]
+            :auto-reverse true}]
+   ["Scale" {:fx/type :scale-transition
+             :by-x 0.2
+             :by-y 1.2
+             :cycle-count :indefinite
+             :duration [1 :s]
+             :auto-reverse true}]
+   ["Stroke" {:fx/type :stroke-transition
+              :from-value :red
+              :to-value :yellow
+              :cycle-count :indefinite
+              :duration [0.5 :s]
+              :auto-reverse true}]
+   ["Rotate" {:fx/type :rotate-transition
+              :duration [0.5 :s]
+              :from-angle 0
+              :to-angle 185
+              :cycle-count :indefinite
+              :auto-reverse true
+              :interpolator :ease-both}]
+   ["Translate" {:fx/type :translate-transition
+                 :duration [0.5 :s]
+                 :from-x 0
+                 :to-x 75
+                 :interpolator :ease-both
+                 :auto-reverse true
+                 :cycle-count :indefinite}]
+   ["Path" {:fx/type :path-transition
+            :path {:fx/type :circle
+                   :radius 35}
+            :duration [1 :s]
+            :interpolator :linear
+            :orientation :orthogonal-to-tanget
+            :cycle-count :indefinite}]
+   ["Parallel" {:fx/type :parallel-transition
+                :auto-reverse true
+                :cycle-count :indefinite
+                ; target node is automatically attached to children
+                ; by JavaFX, if not already bound.
+                :children [{:fx/type :rotate-transition
+                            :duration [0.5 :s]
+                            :from-angle 0
+                            :to-angle 185
+                            :interpolator :ease-both}
+                           {:fx/type :translate-transition
+                            :duration [0.5 :s]
+                            :from-x 0
+                            :to-x 75
+                            :interpolator :ease-both}]}]
+   ["Sequential" {:fx/type :sequential-transition
+                  :auto-reverse true
+                  :cycle-count :indefinite
+                  :children [{:fx/type :rotate-transition
+                              :duration [0.5 :s]
+                              :from-angle 0
+                              :to-angle 185
+                              :interpolator :ease-both}
+                             {:fx/type :translate-transition
+                              :duration [0.5 :s]
+                              :from-x 0
+                              :to-x 75
+                              :interpolator :ease-both}]}]
+   ["Nested" (let [switch-props (fn [props p1 p2]
+                                  (assoc props
+                                         p2 (get props p1)
+                                         p1 (get props p2)))
+                   pause-1s {:fx/type :pause-transition
+                             :duration [1 :s]}
+                   rotate-right {:fx/type :rotate-transition
+                                 :duration [0.5 :s]
+                                 :from-angle 0
+                                 :to-angle 185
+                                 :interpolator :ease-both}
+                   translate-right {:fx/type :translate-transition
+                                    :duration [0.5 :s]
+                                    :from-x 0
+                                    :to-x 75
+                                    :interpolator :ease-both}
+                   rotate-left (switch-props rotate-right :from-angle :to-angle)
+                   translate-left (switch-props translate-right :from-x :to-x)
+                   parallel-dance-right {:fx/type :parallel-transition
+                                         :children [rotate-right
+                                                    translate-right]}
+                   parallel-dance-left {:fx/type :parallel-transition
+                                        :children [rotate-left
+                                                   translate-left]}]
+               {:fx/type :parallel-transition
+                :cycle-count :indefinite
+                :children [{:fx/type :fade-transition
+                            :from-value 1.0
+                            :to-value 0.3
+                            :auto-reverse true
+                            :duration [0.5 :s]
+                            :cycle-count 6}
+                           {:fx/type :sequential-transition
+                            :children [pause-1s
+                                       parallel-dance-right
+                                       pause-1s
+                                       parallel-dance-left]}]})]])
+
+(defn view [{_ :state}]
+  {:fx/type :stage
+   :showing true
+   :always-on-top true
+   :width 600
+   :height 500
+   :scene {:fx/type :scene
+           :root {:fx/type on-grid
+                  :rows 5
+                  :columns 2
+                  :children (mapv
+                              (fn [[header transition]]
+                                (with-header
+                                  header
+                                  {:fx/type start-transition-on
+                                   :transition transition
+                                   ; run each animation on a small rectangle
+                                   :desc {:fx/type :rectangle
+                                          :width 20
+                                          :height 50}}))
+                              indefinite-animations)}}})
+
+(def renderer
+  (fx/create-renderer
+    :middleware (fx/wrap-map-desc (fn [state]
+                                    {:fx/type view
+                                     :state state}))))
+
+(fx/mount-renderer *state renderer)

--- a/src/cljfx/coerce.clj
+++ b/src/cljfx/coerce.clj
@@ -29,7 +29,8 @@
            [javafx.beans.value ObservableValue ChangeListener]
            [javafx.beans Observable InvalidationListener]
            [java.io InputStream]
-           [javafx.collections ListChangeListener]))
+           [javafx.collections ListChangeListener]
+           [javafx.animation Animation Interpolator PathTransition$OrientationType]))
 
 (set! *warn-on-reflection* true)
 
@@ -517,3 +518,46 @@
   (case x
     :use-computed-size -1.0
     (double x)))
+
+(defn animation [x]
+  (cond
+    (= :indefinite x) Animation/INDEFINITE
+    :else (int x)))
+
+(defn interpolator [x]
+  (cond
+    (instance? Interpolator x) x
+    (vector? x) (condp = (nth x 0)
+                  :spline (case (count x)
+                            5 (let [[_ x1 y1 x2 y2] x]
+                                (Interpolator/SPLINE (double x1)
+                                                     (double y1)
+                                                     (double x2)
+                                                     (double y2)))
+                             (fail Interpolator x))
+                  :tangent (case (count x)
+                             3 (let [[_ t v] x]
+                                 (Interpolator/TANGENT (duration t)
+                                                       (double v)))
+                             5 (let [[_ t1 v1 t2 v2] x]
+                                 (Interpolator/TANGENT (duration t1)
+                                                       (double v1)
+                                                       (duration t2)
+                                                       (double v2)))
+                             (fail Interpolator x))
+                  (fail Interpolator x))
+    :else (case x
+            :discrete Interpolator/DISCRETE
+            :ease-both Interpolator/EASE_BOTH
+            :ease-in Interpolator/EASE_IN
+            :ease-out Interpolator/EASE_OUT
+            :linear Interpolator/LINEAR
+            (fail Interpolator x))))
+
+(defn path-transition-orientation [x]
+  (cond
+    (instance? PathTransition$OrientationType x) x
+    :else (case x
+            :none PathTransition$OrientationType/NONE
+            :orthogonal-to-tanget PathTransition$OrientationType/ORTHOGONAL_TO_TANGENT
+            (fail PathTransition$OrientationType x))))

--- a/src/cljfx/coerce.clj
+++ b/src/cljfx/coerce.clj
@@ -29,8 +29,7 @@
            [javafx.beans.value ObservableValue ChangeListener]
            [javafx.beans Observable InvalidationListener]
            [java.io InputStream]
-           [javafx.collections ListChangeListener]
-           [javafx.animation Animation Interpolator PathTransition$OrientationType]))
+           [javafx.collections ListChangeListener]))
 
 (set! *warn-on-reflection* true)
 
@@ -518,46 +517,3 @@
   (case x
     :use-computed-size -1.0
     (double x)))
-
-(defn animation [x]
-  (cond
-    (= :indefinite x) Animation/INDEFINITE
-    :else (int x)))
-
-(defn interpolator [x]
-  (cond
-    (instance? Interpolator x) x
-    (vector? x) (condp = (nth x 0)
-                  :spline (case (count x)
-                            5 (let [[_ x1 y1 x2 y2] x]
-                                (Interpolator/SPLINE (double x1)
-                                                     (double y1)
-                                                     (double x2)
-                                                     (double y2)))
-                             (fail Interpolator x))
-                  :tangent (case (count x)
-                             3 (let [[_ t v] x]
-                                 (Interpolator/TANGENT (duration t)
-                                                       (double v)))
-                             5 (let [[_ t1 v1 t2 v2] x]
-                                 (Interpolator/TANGENT (duration t1)
-                                                       (double v1)
-                                                       (duration t2)
-                                                       (double v2)))
-                             (fail Interpolator x))
-                  (fail Interpolator x))
-    :else (case x
-            :discrete Interpolator/DISCRETE
-            :ease-both Interpolator/EASE_BOTH
-            :ease-in Interpolator/EASE_IN
-            :ease-out Interpolator/EASE_OUT
-            :linear Interpolator/LINEAR
-            (fail Interpolator x))))
-
-(defn path-transition-orientation [x]
-  (cond
-    (instance? PathTransition$OrientationType x) x
-    :else (case x
-            :none PathTransition$OrientationType/NONE
-            :orthogonal-to-tanget PathTransition$OrientationType/ORTHOGONAL_TO_TANGENT
-            (fail PathTransition$OrientationType x))))

--- a/src/cljfx/fx.clj
+++ b/src/cljfx/fx.clj
@@ -170,7 +170,18 @@
    :choice-dialog (lazy-load cljfx.fx.choice-dialog/lifecycle)
    :dialog (lazy-load cljfx.fx.dialog/lifecycle)
    :dialog-pane (lazy-load cljfx.fx.dialog-pane/lifecycle)
-   :text-input-dialog (lazy-load cljfx.fx.text-input-dialog/lifecycle)})
+   :text-input-dialog (lazy-load cljfx.fx.text-input-dialog/lifecycle)
+   ;; transitions
+   :fade-transition (lazy-load cljfx.fx.fade-transition/lifecycle)
+   :fill-transition (lazy-load cljfx.fx.fill-transition/lifecycle)
+   :parallel-transition (lazy-load cljfx.fx.parallel-transition/lifecycle)
+   :path-transition (lazy-load cljfx.fx.path-transition/lifecycle)
+   :pause-transition (lazy-load cljfx.fx.pause-transition/lifecycle)
+   :rotate-transition (lazy-load cljfx.fx.rotate-transition/lifecycle)
+   :scale-transition (lazy-load cljfx.fx.scale-transition/lifecycle)
+   :sequential-transition (lazy-load cljfx.fx.sequential-transition/lifecycle)
+   :stroke-transition (lazy-load cljfx.fx.stroke-transition/lifecycle)
+   :translate-transition (lazy-load cljfx.fx.translate-transition/lifecycle)})
 
 (defn keyword->lifecycle [kw]
   (when-let [*delay (keyword->lifecycle-delay kw)]

--- a/src/cljfx/fx/animation.clj
+++ b/src/cljfx/fx/animation.clj
@@ -1,0 +1,41 @@
+(ns cljfx.fx.animation
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.mutator :as mutator])
+  (:import [javafx.animation Animation]
+           [javafx.util Duration]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (composite/props Animation
+    :auto-reverse [:setter lifecycle/scalar :default false]
+    :on-auto-reverse-changed [:property-change-listener lifecycle/change-listener]
+    :on-current-time-changed [:property-change-listener lifecycle/change-listener]
+    :cycle-count [:setter lifecycle/scalar :coerce coerce/animation :default 1.0]
+    :on-cycle-count-changed [:property-change-listener lifecycle/change-listener]
+    :on-cycle-duration-changed [:property-change-listener lifecycle/change-listener]
+    :delay [:setter lifecycle/scalar :coerce coerce/duration :default 0]
+    :on-delay-changed [:property-change-listener lifecycle/change-listener]
+    :on-finished [:setter lifecycle/event-handler :coerce coerce/event-handler :default nil]
+    :on-on-finished-changed [:property-change-listener lifecycle/change-listener]
+    :rate [:setter lifecycle/scalar :coerce double :default 1.0]
+    :on-rate-changed [:property-change-listener lifecycle/change-listener]
+    :jump-to [(mutator/setter
+                #(if (string? %2)
+                   (.jumpTo ^Animation %1 ^String %2)
+                   (.jumpTo ^Animation %1 ^Duration %2)))
+              lifecycle/scalar
+              :coerce #(if (string? %)
+                         %
+                         (coerce/duration %))]
+    :on-status-changed [:property-change-listener lifecycle/change-listener]
+    :status [(mutator/setter
+               #(case %2
+                  :running (.play ^Animation %1)
+                  :paused (.pause ^Animation %1)
+                  :stopped (.stop ^Animation %1)))
+             lifecycle/scalar
+             :default :stopped]))

--- a/src/cljfx/fx/animation.clj
+++ b/src/cljfx/fx/animation.clj
@@ -9,17 +9,22 @@
 
 (set! *warn-on-reflection* true)
 
+(defn coerce-animation [x]
+  (case x
+    :indefinite Animation/INDEFINITE
+    (int x)))
+
 (def props
   (composite/props Animation
     :auto-reverse [:setter lifecycle/scalar :default false]
     :on-auto-reverse-changed [:property-change-listener lifecycle/change-listener]
     :on-current-time-changed [:property-change-listener lifecycle/change-listener]
-    :cycle-count [:setter lifecycle/scalar :coerce coerce/animation :default 1.0]
+    :cycle-count [:setter lifecycle/scalar :coerce coerce-animation :default 1]
     :on-cycle-count-changed [:property-change-listener lifecycle/change-listener]
     :on-cycle-duration-changed [:property-change-listener lifecycle/change-listener]
     :delay [:setter lifecycle/scalar :coerce coerce/duration :default 0]
     :on-delay-changed [:property-change-listener lifecycle/change-listener]
-    :on-finished [:setter lifecycle/event-handler :coerce coerce/event-handler :default nil]
+    :on-finished [:setter lifecycle/event-handler :coerce coerce/event-handler]
     :on-on-finished-changed [:property-change-listener lifecycle/change-listener]
     :rate [:setter lifecycle/scalar :coerce double :default 1.0]
     :on-rate-changed [:property-change-listener lifecycle/change-listener]

--- a/src/cljfx/fx/fade_transition.clj
+++ b/src/cljfx/fx/fade_transition.clj
@@ -1,0 +1,25 @@
+(ns cljfx.fx.fade-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation FadeTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props FadeTransition
+      :node [:setter lifecycle/dynamic]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
+      :from-value [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-value [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :by-value [:setter lifecycle/scalar :coerce double])))
+
+(def lifecycle
+  (composite/describe FadeTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/fade_transition.clj
+++ b/src/cljfx/fx/fade_transition.clj
@@ -16,7 +16,7 @@
       :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
       :from-value [:setter lifecycle/scalar :coerce double :default ##NaN]
       :to-value [:setter lifecycle/scalar :coerce double :default ##NaN]
-      :by-value [:setter lifecycle/scalar :coerce double])))
+      :by-value [:setter lifecycle/scalar :coerce double :default 0])))
 
 (def lifecycle
   (composite/describe FadeTransition

--- a/src/cljfx/fx/fill_transition.clj
+++ b/src/cljfx/fx/fill_transition.clj
@@ -1,0 +1,24 @@
+(ns cljfx.fx.fill-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation FillTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props FillTransition
+      :shape [:setter lifecycle/dynamic]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
+      :from-value [:setter lifecycle/scalar :coerce coerce/color :default nil]
+      :to-value [:setter lifecycle/scalar :coerce coerce/color :default nil])))
+
+(def lifecycle
+  (composite/describe FillTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/fill_transition.clj
+++ b/src/cljfx/fx/fill_transition.clj
@@ -14,8 +14,8 @@
     (composite/props FillTransition
       :shape [:setter lifecycle/dynamic]
       :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
-      :from-value [:setter lifecycle/scalar :coerce coerce/color :default nil]
-      :to-value [:setter lifecycle/scalar :coerce coerce/color :default nil])))
+      :from-value [:setter lifecycle/scalar :coerce coerce/color]
+      :to-value [:setter lifecycle/scalar :coerce coerce/color])))
 
 (def lifecycle
   (composite/describe FillTransition

--- a/src/cljfx/fx/parallel_transition.clj
+++ b/src/cljfx/fx/parallel_transition.clj
@@ -1,0 +1,21 @@
+(ns cljfx.fx.parallel-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation ParallelTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props ParallelTransition
+      :children [:list lifecycle/dynamics]
+      :node [:setter lifecycle/dynamic])))
+
+(def lifecycle
+  (composite/describe ParallelTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/path_transition.clj
+++ b/src/cljfx/fx/path_transition.clj
@@ -1,0 +1,24 @@
+(ns cljfx.fx.path-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation PathTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props PathTransition
+      :node [:setter lifecycle/dynamic]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
+      :path [:setter lifecycle/dynamic]
+      :orientation [:setter lifecycle/scalar :coerce coerce/path-transition-orientation :default :none])))
+
+(def lifecycle
+  (composite/describe PathTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/path_transition.clj
+++ b/src/cljfx/fx/path_transition.clj
@@ -4,7 +4,7 @@
             [cljfx.lifecycle :as lifecycle]
             [cljfx.coerce :as coerce]
             [cljfx.fx.transition :as fx.transition])
-  (:import [javafx.animation PathTransition]))
+  (:import [javafx.animation PathTransition PathTransition$OrientationType]))
 
 (set! *warn-on-reflection* true)
 
@@ -15,7 +15,7 @@
       :node [:setter lifecycle/dynamic]
       :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
       :path [:setter lifecycle/dynamic]
-      :orientation [:setter lifecycle/scalar :coerce coerce/path-transition-orientation :default :none])))
+      :orientation [:setter lifecycle/scalar :coerce (coerce/enum PathTransition$OrientationType) :default :none])))
 
 (def lifecycle
   (composite/describe PathTransition

--- a/src/cljfx/fx/pause_transition.clj
+++ b/src/cljfx/fx/pause_transition.clj
@@ -1,0 +1,21 @@
+(ns cljfx.fx.pause-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation PauseTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props PauseTransition
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400])))
+
+(def lifecycle
+  (composite/describe PauseTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/rotate_transition.clj
+++ b/src/cljfx/fx/rotate_transition.clj
@@ -1,0 +1,27 @@
+(ns cljfx.fx.rotate-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.mutator :as mutator]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation RotateTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props RotateTransition
+      :axis [:setter lifecycle/scalar :coerce coerce/point-3d]
+      :by-angle [:setter lifecycle/scalar :coerce double :default 0.0]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 0]
+      :from-angle [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-angle [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :node [:setter lifecycle/dynamic])))
+
+(def lifecycle
+  (composite/describe RotateTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/rotate_transition.clj
+++ b/src/cljfx/fx/rotate_transition.clj
@@ -3,7 +3,6 @@
   (:require [cljfx.composite :as composite]
             [cljfx.lifecycle :as lifecycle]
             [cljfx.coerce :as coerce]
-            [cljfx.mutator :as mutator]
             [cljfx.fx.transition :as fx.transition])
   (:import [javafx.animation RotateTransition]))
 

--- a/src/cljfx/fx/scale_transition.clj
+++ b/src/cljfx/fx/scale_transition.clj
@@ -1,0 +1,31 @@
+(ns cljfx.fx.scale-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation ScaleTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props ScaleTransition
+      :node [:setter lifecycle/dynamic]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
+      :from-x [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :from-y [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :from-z [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-x [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-y [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-z [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :by-x [:setter lifecycle/scalar :coerce double]
+      :by-y [:setter lifecycle/scalar :coerce double]
+      :by-z [:setter lifecycle/scalar :coerce double])))
+
+(def lifecycle
+  (composite/describe ScaleTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/scale_transition.clj
+++ b/src/cljfx/fx/scale_transition.clj
@@ -20,9 +20,9 @@
       :to-x [:setter lifecycle/scalar :coerce double :default ##NaN]
       :to-y [:setter lifecycle/scalar :coerce double :default ##NaN]
       :to-z [:setter lifecycle/scalar :coerce double :default ##NaN]
-      :by-x [:setter lifecycle/scalar :coerce double]
-      :by-y [:setter lifecycle/scalar :coerce double]
-      :by-z [:setter lifecycle/scalar :coerce double])))
+      :by-x [:setter lifecycle/scalar :coerce double :default 0]
+      :by-y [:setter lifecycle/scalar :coerce double :default 0]
+      :by-z [:setter lifecycle/scalar :coerce double :default 0])))
 
 (def lifecycle
   (composite/describe ScaleTransition

--- a/src/cljfx/fx/sequential_transition.clj
+++ b/src/cljfx/fx/sequential_transition.clj
@@ -1,0 +1,21 @@
+(ns cljfx.fx.sequential-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation SequentialTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props SequentialTransition
+      :children [:list lifecycle/dynamics]
+      :node [:setter lifecycle/dynamic])))
+
+(def lifecycle
+  (composite/describe SequentialTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/stroke_transition.clj
+++ b/src/cljfx/fx/stroke_transition.clj
@@ -1,0 +1,24 @@
+(ns cljfx.fx.stroke-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation StrokeTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props StrokeTransition
+      :shape [:setter lifecycle/dynamic]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
+      :from-value [:setter lifecycle/scalar :coerce coerce/color :default nil]
+      :to-value [:setter lifecycle/scalar :coerce coerce/color :default nil])))
+
+(def lifecycle
+  (composite/describe StrokeTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/stroke_transition.clj
+++ b/src/cljfx/fx/stroke_transition.clj
@@ -14,8 +14,8 @@
     (composite/props StrokeTransition
       :shape [:setter lifecycle/dynamic]
       :duration [:setter lifecycle/scalar :coerce coerce/duration :default 400]
-      :from-value [:setter lifecycle/scalar :coerce coerce/color :default nil]
-      :to-value [:setter lifecycle/scalar :coerce coerce/color :default nil])))
+      :from-value [:setter lifecycle/scalar :coerce coerce/color]
+      :to-value [:setter lifecycle/scalar :coerce coerce/color])))
 
 (def lifecycle
   (composite/describe StrokeTransition

--- a/src/cljfx/fx/transition.clj
+++ b/src/cljfx/fx/transition.clj
@@ -1,0 +1,15 @@
+(ns cljfx.fx.transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.fx.animation :as fx.animation])
+  (:import [javafx.animation Transition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.animation/props
+    (composite/props Transition
+      :interpolator [:setter lifecycle/scalar :coerce coerce/interpolator :default :ease-in])))

--- a/src/cljfx/fx/transition.clj
+++ b/src/cljfx/fx/transition.clj
@@ -4,12 +4,42 @@
             [cljfx.lifecycle :as lifecycle]
             [cljfx.coerce :as coerce]
             [cljfx.fx.animation :as fx.animation])
-  (:import [javafx.animation Transition]))
+  (:import [javafx.animation Transition Interpolator]))
 
 (set! *warn-on-reflection* true)
+
+(defn coerce-interpolator [x]
+  (cond
+    (instance? Interpolator x) x
+    (vector? x) (case (nth x 0)
+                  :spline (case (count x)
+                            5 (let [[_ x1 y1 x2 y2] x]
+                                (Interpolator/SPLINE (double x1)
+                                                     (double y1)
+                                                     (double x2)
+                                                     (double y2)))
+                             (coerce/fail Interpolator x))
+                  :tangent (case (count x)
+                             3 (let [[_ t v] x]
+                                 (Interpolator/TANGENT (coerce/duration t)
+                                                       (double v)))
+                             5 (let [[_ t1 v1 t2 v2] x]
+                                 (Interpolator/TANGENT (coerce/duration t1)
+                                                       (double v1)
+                                                       (coerce/duration t2)
+                                                       (double v2)))
+                             (coerce/fail Interpolator x))
+                  (coerce/fail Interpolator x))
+    :else (case x
+            :discrete Interpolator/DISCRETE
+            :ease-both Interpolator/EASE_BOTH
+            :ease-in Interpolator/EASE_IN
+            :ease-out Interpolator/EASE_OUT
+            :linear Interpolator/LINEAR
+            (coerce/fail Interpolator x))))
 
 (def props
   (merge
     fx.animation/props
     (composite/props Transition
-      :interpolator [:setter lifecycle/scalar :coerce coerce/interpolator :default :ease-in])))
+      :interpolator [:setter lifecycle/scalar :coerce coerce-interpolator :default :ease-in])))

--- a/src/cljfx/fx/translate_transition.clj
+++ b/src/cljfx/fx/translate_transition.clj
@@ -1,0 +1,39 @@
+(ns cljfx.fx.translate-transition
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.coerce :as coerce]
+            [cljfx.mutator :as mutator]
+            [cljfx.fx.transition :as fx.transition])
+  (:import [javafx.animation TranslateTransition]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.transition/props
+    (composite/props TranslateTransition
+      :by-x [:setter lifecycle/scalar :coerce double :default 0.0]
+      :by-y [:setter lifecycle/scalar :coerce double :default 0.0]
+      :by-z [:setter lifecycle/scalar :coerce double :default 0.0]
+      :duration [:setter lifecycle/scalar :coerce coerce/duration
+                 :default 400]
+      :from-x [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :from-y [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :from-z [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :node [:setter lifecycle/dynamic]
+      :to-x [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-y [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :to-z [:setter lifecycle/scalar :coerce double :default ##NaN]
+      :state [(mutator/setter
+                #(case %2
+                   :playing (.play ^TranslateTransition %1)
+                   :stopped (.stop ^TranslateTransition %1)))
+              lifecycle/scalar
+              :default :stopped])))
+
+(def lifecycle
+  (composite/describe TranslateTransition
+    :ctor []
+    :prop-order {:status 1}
+    :props props))

--- a/src/cljfx/fx/translate_transition.clj
+++ b/src/cljfx/fx/translate_transition.clj
@@ -24,13 +24,7 @@
       :node [:setter lifecycle/dynamic]
       :to-x [:setter lifecycle/scalar :coerce double :default ##NaN]
       :to-y [:setter lifecycle/scalar :coerce double :default ##NaN]
-      :to-z [:setter lifecycle/scalar :coerce double :default ##NaN]
-      :state [(mutator/setter
-                #(case %2
-                   :playing (.play ^TranslateTransition %1)
-                   :stopped (.stop ^TranslateTransition %1)))
-              lifecycle/scalar
-              :default :stopped])))
+      :to-z [:setter lifecycle/scalar :coerce double :default ##NaN])))
 
 (def lifecycle
   (composite/describe TranslateTransition


### PR DESCRIPTION
Based on the feedback of #30, this PR adds support for JavaFX transitions.

The example demonstrates all transitions using `:indefinite` cycles. I haven't tried transitions that are more responsive, and we should probably try them before merging this.

[Example gif](https://user-images.githubusercontent.com/287396/61163321-645b2a00-a4db-11e9-9309-2fa10ed44e67.gif)
