### PR TITLE
treat missing entries in context as nil entries

### DIFF
--- a/src/cljfx/context.clj
+++ b/src/cljfx/context.clj
@@ -149,7 +149,11 @@ Possible reasons:
     (some #(contains? s2 %) s1)))
 
 (defn- invalidate-cache [cache old-m new-m]
-  (let [changed-keys (into #{} (remove #(= (old-m %) (new-m %))) (keys old-m))
+  (let [changed-keys (into #{}
+                           (comp (mapcat keys)
+                                 (distinct)
+                                 (remove #(= (old-m %) (new-m %))))
+                           [old-m new-m])
         changed-sub-ids (into #{} (map vector) changed-keys)]
     (reduce (fn [acc [k v]]
               (let [direct-deps (::direct-deps v)]

--- a/test/cljfx/context_test.clj
+++ b/test/cljfx/context_test.clj
@@ -20,7 +20,14 @@
                  (context/sub context fib (- n 1)))))]
     (context/sub context f 10)
     (fact
-      @*tracker => 11)))
+      @*tracker => 11))
+  (testing "a missing entry is treated like a nil entry"
+    (let [context (context/create {} identity)
+          f #(context/sub % :entry)
+          _ (fact (context/sub context f) => nil)
+          context (context/swap context assoc :entry 0)
+          _ (fact (context/sub context f) => 0)
+          ])))
 
 (deftest after-changing-context-only-affected-subscriptions-are-recalculated
   (let [*greeting-call-counter (atom 0)
@@ -162,4 +169,3 @@
             "Updating context with independent change does not trigger recalculation"
             (context/sub context-3 inc-db) => 3
             @*inc-db-call-counter => 2)]))
-

--- a/test/cljfx/context_test/empty_context.clj
+++ b/test/cljfx/context_test/empty_context.clj
@@ -1,0 +1,72 @@
+(ns cljfx.context-test.empty-context
+  (:require [cljfx.api :as fx]))
+
+; minimal example of bug in context where adding
+; a new entry to the root of the context does not
+; trigger rerenderings.
+
+; To reproduce:
+; 1. Run this file.
+; 2. Click the "Clicked x0" button a few times, it works.
+; 3. Click the "Reset via assoc" button, again Step 2 works fine.
+; 4. Click the "Reset via dissoc" button. Now, Step 2 skips "Clicked x1",
+;    and "Clicked x0" is shown twice!
+
+;; Initial State
+
+(defn init-state [] {::clicked nil})
+
+;; Views
+
+(defn view [{:keys [fx/context]}]
+  {:fx/type :stage
+   :showing true
+   :always-on-top true
+   :width 600
+   :height 500
+   :scene {:fx/type :scene
+           :root {:fx/type :v-box
+                  :children [{:fx/type :h-box
+                              :children [{:fx/type :button
+                                          :on-action {:event/type ::reset-assoc}
+                                          :text (str "Reset via assoc")}
+                                         {:fx/type :button
+                                          :on-action {:event/type ::reset-dissoc}
+                                          :text (str "Reset via dissoc")}]}
+                             (let [clicked (fx/sub context ::clicked)]
+                               {:fx/type :button
+                                :on-action {:event/type ::clicked
+                                            :clicked clicked}
+                                :text (str "Clicked x" (or clicked 0))}) ]}}})
+
+; Handlers
+
+(defmulti handler :event/type)
+(defmethod handler ::clicked
+  [{:keys [fx/context clicked]}]
+  {:context (fx/swap-context context update ::clicked (fnil inc 0))})
+
+(defmethod handler ::reset-dissoc
+  [{:keys [fx/context]}]
+  {:context (fx/swap-context context dissoc ::clicked)})
+
+(defmethod handler ::reset-assoc
+  [{:keys [fx/context]}]
+  {:context (fx/swap-context context assoc ::clicked nil)})
+
+;; Main app
+
+(declare *context app)
+
+(when (and (.hasRoot #'*context)
+           (.hasRoot #'app))
+  (fx/unmount-renderer *context (:renderer app)))
+
+(def *context
+  (atom (fx/create-context (init-state))))
+
+(def app
+  (fx/create-app *context
+    :event-handler handler
+    :desc-fn (fn [_]
+               {:fx/type view})))


### PR DESCRIPTION
# Problem
Adding new entries to the root of the context doesn't trigger rerenderings.
See `cljfx.context-test.empty-context` for a minimal example.
Notice "x1" is skipped after dissoc:
![context-bug](https://user-images.githubusercontent.com/287396/61912637-b30bb980-af08-11e9-8456-6d1d5d199797.gif)


# Solution
Improve cache invalidation logic to recognize newly added keys. These two old-map/new-map cases now behave identically:
```clojure
  {:foo nil} => {:foo 1}
  {}         => {:foo 1}
```

Final result: "x1" is shown after dissoc
![context-bug-fixed](https://user-images.githubusercontent.com/287396/61912641-b69f4080-af08-11e9-94fb-ae778e4dd09a.gif)

