### PR TITLE
Adds support for type-fn multimethods

### DIFF
--- a/src/cljfx/defaults.clj
+++ b/src/cljfx/defaults.clj
@@ -5,7 +5,9 @@
             [cljfx.event-handler :as event-handler]))
 
 (defn fn->lifecycle [fx-type]
-  (when (fn? fx-type) lifecycle/dynamic-fn->dynamic))
+  (when (or (fn? fx-type)
+            (instance? clojure.lang.MultiFn fx-type))
+    lifecycle/dynamic-fn->dynamic))
 
 (defn- fx-type->lifecycle [fx-type]
   (or (fx/keyword->lifecycle fx-type)


### PR DESCRIPTION
This PR makes it possible to have multimethods as type-fns. It's pretty basic, I didn't think any more changes were needed. Let me know If there's something else to do.