### PR TITLE
Add on-value-changed to spinner

### DIFF
--- a/src/cljfx/fx/spinner.clj
+++ b/src/cljfx/fx/spinner.clj
@@ -21,6 +21,7 @@
                         :default :spinner]
       ;; definitions
       :editable [:setter lifecycle/scalar :default false]
+      :on-value-changed [:property-change-listener lifecycle/change-listener]
       :value-factory [:setter lifecycle/dynamic])))
 
 (def lifecycle


### PR DESCRIPTION
i only have a rough understanding of cljfx/JavaFX, but i believe that this change should make the spinner type more useful for cljfx users.

# rationale

with cljfx @ 1.6.7, i can't tell how to put an event listener on a spinner. looking at JavaFX, the `Spinner` and `Slider` classes both seem to handle their values similarly; both have a `value` property to which listeners can be added with `addListener`. seeing that cljfx has `:on-value-changed` defined for slider, it makes sense to me to define `:on-value-changed` for spinner.

this PR might relate to https://github.com/cljfx/cljfx/issues/61; if my understanding is correct, the changes in this PR would obviate the cljfx extension given in https://github.com/cljfx/cljfx/issues/61#issuecomment-602822791