### PR TITLE
Permit fx/sub'ing to nested values

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ black-box wrapper around application state map, with an api
 function `fx/sub` to look inside wrapped state. `fx/sub` usage has 2
 flavors:
 1. Keys: anything except function, will return corresponding value from
-   wrapped map.
+   wrapped map. Multiple keys can be passed to subscribe to nested values.
 2. Subscription functions: any function that receives context as first
    argument. `fx/sub`-scribing to such functions will lead to a call to
    this function, and it in turn may subscribe to other keys and

--- a/examples/e13_re_frame_like_state.clj
+++ b/examples/e13_re_frame_like_state.clj
@@ -38,10 +38,10 @@
   (sort (keys (fx/sub context :id->ingredient))))
 
 (defn sub-id->potion [context id]
-  (get (fx/sub context :id->potion) id))
+  (fx/sub context :id->potion id))
 
 (defn sub-id->ingredient [context id]
-  (get (fx/sub context :id->ingredient) id))
+  (fx/sub context :id->ingredient id))
 
 (defmulti event-handler :event/type)
 

--- a/examples/e15_task_tracker.clj
+++ b/examples/e15_task_tracker.clj
@@ -40,10 +40,10 @@
   (count (fx/sub context sub-task-state->task-ids task-state)))
 
 (defn sub-task-by-id [context i]
-  (get (fx/sub context :tasks) i))
+  (fx/sub context :tasks i))
 
 (defn sub-user-by-id [context i]
-  (get (fx/sub context :users) i))
+  (fx/sub context :users i))
 
 (defn sub-all-users [context]
   (->> (fx/sub context :users)

--- a/examples/e18_pure_event_handling/events.clj
+++ b/examples/e18_pure_event_handling/events.clj
@@ -47,7 +47,7 @@
 
 (defmethod event-handler ::go-back [{:keys [fx/context]}]
   (let [new-active-request-id (peek (pop (fx/sub context :history)))
-        url (:url (fx/sub context subs/response-by-request-id new-active-request-id))]
+        url (fx/sub context :request-id->response new-active-request-id :url)]
     {:context (fx/swap-context context #(-> %
                                             (update :history pop)
                                             (assoc :typed-url url)))}))

--- a/examples/e18_pure_event_handling/subs.clj
+++ b/examples/e18_pure_event_handling/subs.clj
@@ -5,23 +5,18 @@
 (defn current-request-id [context]
   (peek (fx/sub context :history)))
 
-(defn response-by-request-id [context request-id]
-  (get (fx/sub context :request-id->response) request-id))
-
 (defn context-type [context request-id]
-  (-> (fx/sub context response-by-request-id request-id)
-      :response
-      :headers
+  (-> (fx/sub context :request-id->response request-id :response :headers)
       (get "Content-Type")
       (str/split #";\s*")
       first))
 
 (defn body [context request-id]
-  (:body (:response (fx/sub context response-by-request-id request-id))))
+  (fx/sub context :request-id->response request-id :response :body))
 
 (defn current-response [context]
   (let [id (fx/sub context current-request-id)]
-    (fx/sub context response-by-request-id id)))
+    (fx/sub context :request-id->response id)))
 
 (defn history-empty? [context]
   (empty? (fx/sub context :history)))

--- a/examples/e22_button_with_confirmation_dialog.clj
+++ b/examples/e22_button_with_confirmation_dialog.clj
@@ -17,11 +17,8 @@
 
 ;; Subscriptions of `button-with-confirmation-dialog` component
 
-(defn confirmation-state-sub [context state-id]
-  (get (fx/sub context :internal) state-id))
-
 (defn confirmation-showing-sub [context state-id]
-  (:showing (fx/sub context confirmation-state-sub state-id) false))
+  (boolean (fx/sub context :internal state-id :showing)))
 
 ;; Events of `button-with-confirmation-dialog` component
 

--- a/src/cljfx/api.clj
+++ b/src/cljfx/api.clj
@@ -359,10 +359,10 @@
    (context/create m cache-factory)))
 
 (defn sub
-  "Subscribe to a key or subscription function in this context
+  "Subscribe to a series of keys or subscription function in this context
 
-  Subscribing to a key (which may be anything except functions) will return a value
-  corresponding to that key (via `get`) in underlying context map
+  Subscribing to a series of keys (which may be anything except functions) will
+  return a value corresponding to those keys (via `get-in`) in underlying context map
 
   Subscription function is any function that expects context as it's first argument
 

--- a/src/cljfx/context.clj
+++ b/src/cljfx/context.clj
@@ -103,8 +103,8 @@ Possible reasons:
     ::context
     (assoc deps k v)))
 
-(defn- key-sub [ctx k]
-  (get (sub ctx) k))
+(defn- keys-sub [ctx & ks]
+  (get-in (sub ctx) (vec ks)))
 
 (defn sub
   ([context]
@@ -115,15 +115,9 @@ Possible reasons:
        (reset! *deps ::context))
      m))
   ([context k & args]
-   (let [sub-id (cond
-                  (fn? k)
+   (let [sub-id (if (fn? k)
                   (apply vector k args)
-
-                  (seq args)
-                  (throw (ex-info "Subscribing to keys does not allow additional args"
-                                  {:k k :args args}))
-                  :else
-                  [key-sub k])
+                  (apply vector keys-sub k args))
          {::keys [*cache *deps generation]} context
          cache @*cache
          existing-entry (lookup cache sub-id)


### PR DESCRIPTION
Fixes #84 

I also updated the examples to use this new feature. Now that some of the sub-fns are very simple, they _could_ be removed and their call sites could be replaced with their bodies, but they're not doing any harm really and they add some clarity.