### PR TITLE
add date-cell

### DIFF
--- a/src/cljfx/fx.clj
+++ b/src/cljfx/fx.clj
@@ -162,6 +162,7 @@
    :tree-view (lazy-load cljfx.fx.tree-view/lifecycle)
    ;; cells
    :cell (lazy-load cljfx.fx.cell/lifecycle)
+   :date-cell (lazy-load cljfx.fx.date-cell/lifecycle)
    :indexed-cell (lazy-load cljfx.fx.indexed-cell/lifecycle)
    :list-cell (lazy-load cljfx.fx.list-cell/lifecycle)
    :combo-box-list-cell (lazy-load cljfx.fx.combo-box-list-cell/lifecycle)


### PR DESCRIPTION
@vlaaad In my previous PR, I found out that `cljfx.fx.date-cell` ns never used, I assume it's forgotten to be added into `keyword->lifecycle-delay` hash map. So I've added `:date-cell` component.