### PR TITLE
Add support for static content in a web view

### DIFF
--- a/src/cljfx/fx/web_view.clj
+++ b/src/cljfx/fx/web_view.clj
@@ -32,7 +32,8 @@
       :pref-height [:setter lifecycle/scalar :coerce double :default 600.0]
       :pref-width [:setter lifecycle/scalar :coerce double :default 800.0]
       :zoom [:setter lifecycle/scalar :coerce double :default 1.0]
-      :url [(mutator/setter #(.load (.getEngine ^WebView %1) %2)) lifecycle/scalar])))
+      :url [(mutator/setter #(.load (.getEngine ^WebView %1) %2)) lifecycle/scalar]
+      :content [(mutator/setter #(.loadContent (.getEngine ^WebView %1) %2 "text/html")) lifecycle/scalar])))
 
 (def lifecycle
   (composite/describe WebView


### PR DESCRIPTION
This adds `:content` prop to a `web-view`, which will call the [loadContent](https://openjfx.io/javadoc/15/javafx.web/javafx/scene/web/WebEngine.html#loadContent(java.lang.String,java.lang.String)) method