### PR TITLE
Issue 102. Fixed combo-box items update.

### DIFF
--- a/src/cljfx/coerce.clj
+++ b/src/cljfx/coerce.clj
@@ -1,7 +1,7 @@
 (ns cljfx.coerce
   "Part of a public API"
   (:require [clojure.string :as str])
-  (:import [java.util List Locale]
+  (:import [java.util List Locale Collection]
            [javafx.event EventHandler]
            [javafx.scene Cursor]
            [javafx.scene.image Image]
@@ -29,7 +29,7 @@
            [javafx.beans.value ObservableValue ChangeListener]
            [javafx.beans Observable InvalidationListener]
            [java.io InputStream]
-           [javafx.collections ListChangeListener]))
+           [javafx.collections ListChangeListener ObservableList FXCollections]))
 
 (set! *warn-on-reflection* true)
 
@@ -518,3 +518,9 @@
   (case x
     :use-computed-size -1.0
     (double x)))
+
+(defn observable-list [x]
+  (cond
+    (instance? ObservableList x) x
+    (instance? Collection x) (FXCollections/observableArrayList ^Collection x)
+    :else (fail ObservableList x)))

--- a/src/cljfx/fx/combo_box.clj
+++ b/src/cljfx/fx/combo_box.clj
@@ -44,7 +44,7 @@
                      :coerce cell-factory]
       :converter [:setter lifecycle/scalar :coerce coerce/string-converter
                   :default :default]
-      :items [:list lifecycle/scalar]
+      :items [:setter lifecycle/scalar :coerce coerce/observable-list]
       :placeholder [:setter lifecycle/dynamic]
       :visible-row-count [:setter lifecycle/scalar :coerce int :default 10])))
 

--- a/src/cljfx/fx/list_spinner_value_factory.clj
+++ b/src/cljfx/fx/list_spinner_value_factory.clj
@@ -10,17 +10,11 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- observable-list [x]
-  (cond
-    (instance? ObservableList x) x
-    (instance? Collection x) (FXCollections/observableArrayList ^Collection x)
-    :else (coerce/fail ObservableList x)))
-
 (def props
   (merge
     fx.spinner-value-factory/props
     (composite/props SpinnerValueFactory$ListSpinnerValueFactory
-      :items [:list lifecycle/scalar :coerce observable-list])))
+      :items [:list lifecycle/scalar :coerce coerce/observable-list])))
 
 (def lifecycle
   (composite/describe SpinnerValueFactory$ListSpinnerValueFactory


### PR DESCRIPTION
https://github.com/cljfx/cljfx/issues/102

Replacing list items in a `ComboBox` via `ObservableList/setAll` (ie,  `combox.getItems().setAll(...)`) causes the selected item to be lost by the underlying JavaFX component state. Using the `ComboBox`'s `.setItem` method directly fixes the issue.

This PR configures cljfx/combo-box to use the direct component setter instead of the observable list update.

A private `observable-list` coercion function is relocated to the `coerce` namespace so that it can be used by `combo-box`.

I've tested that this fixes the issue and ran the unit tests via `clj -M:test:runner`.

(Let me know if you'd like any changes, additions, tests to this PR.)