### PR TITLE
Add arity-1 to fx/sub-val to return entire context value

### DIFF
--- a/src/cljfx/api.clj
+++ b/src/cljfx/api.clj
@@ -368,9 +368,13 @@
   This creates a direct subscription that will be recalculated whenever the context
   changes.
 
-  Should be fast as [[get]]"
-  [context f & args]
-  (apply context/sub-val context f args))
+  Should be fast as [[get]]
+
+  When called without subscription function, returns the underlying context map"
+  ([context]
+   (context/sub-val context))
+  ([context f & args]
+   (apply context/sub-val context f args)))
 
 (defn sub-ctx
   "Subscribe to a function that receives the context

--- a/src/cljfx/context.clj
+++ b/src/cljfx/context.clj
@@ -134,8 +134,11 @@ Possible reasons:
       (reset! *deps ::context))
     (apply f m args)))
 
-(defn sub-val [context f & args]
-  (sub-ctx context sub-val-sub f args))
+(defn sub-val
+  ([context]
+   (sub-val context identity))
+  ([context f & args]
+   (sub-ctx context sub-val-sub f args)))
 
 (defn reset [context new-m]
   (let [{::keys [*cache *deps generation]} context
@@ -159,7 +162,7 @@ Possible reasons:
   (swap! (::*cache context) #(reduce evict % (keys %))))
 
 (defn ^:deprecated sub
-  ([context] (sub-val context identity))
+  ([context] (sub-val context))
   ([context k & args]
    (cond
      (fn? k) (apply sub-ctx context k args)


### PR DESCRIPTION
I liked how convenient `(fx/sub context)` was for getting the entire context value so I added that functionality back for `fx/sub-val`, so now you can use `(fx/sub-val context)` to get the entire context value.