### PR TITLE
[Idea] Managing existing instances with `desc` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,26 @@ Sometimes components accept specially treated keys. Main uses are:
 
    For a more complete example of available pane keys, see
    [examples/e07_extra_props.clj](examples/e07_extra_props.clj)
+3. Managing existing instances with full description support.
+   On occasion, you may want to manage an externally created JavaFX object as if it were
+   created by cljfx. This is particularly useful when using JavaFX
+   preloaders (see the JavaFX ["Sharing the Stage"](https://docs.oracle.com/javafx/2/deployment/preloaders.htm#BABBBBBJ)
+   tutorial).
+   ```clojure
+   ;; created by the preloader, for example
+   (def externally-created-stage ...)
+   (fx/create-component
+     {:fx/type :stage
+      ;; share the same stage as the preloader
+      :fx/manage-instance externally-created-stage
+      ;; add new props like normal -- old props will be "inherited"
+      ;; from external instance.
+      :width 500
+      :height 600})
+   ```
+
+   See [examples/e41_manage_instance.clj](examples/e41_manage_instance.clj)
+   for a runnable example.
 
 ### Factory props
 
@@ -698,6 +718,8 @@ prefix in their names.
         :create #(Duration/valueOf "10ms")}))
    => #object[javafx.util.Duration 0x2f5eb358 "10.0 ms"]
    ```
+
+   See `:fx/manage-instance` for using descriptions with existing instances.
    
 2. `fx/ext-on-instance-lifecycle`
 

--- a/examples/e41_manage_instance.clj
+++ b/examples/e41_manage_instance.clj
@@ -1,0 +1,30 @@
+(ns e41-manage-instance
+  (:require [cljfx.api :as fx])
+  (:import [javafx.scene Scene]
+           [javafx.stage Stage]
+           [javafx.scene.layout VBox]
+           [javafx.scene.control Label]))
+
+(set! *warn-on-reflection* true)
+
+(def externally-created-stage
+  @(fx/on-fx-thread
+     (doto (Stage.)
+       (.setScene (Scene. (VBox.
+                            ^"[Ljavafx.scene.Node;"
+                            (into-array [(Label. "Unmanaged")]))))
+       (.setWidth 400)
+       (.setHeight 400)
+       (.show))))
+
+(Thread/sleep 1000)
+
+@(fx/on-fx-thread
+   (fx/create-component
+     {:fx/type :stage
+      :fx/manage-instance externally-created-stage
+      :showing true
+      :scene {:fx/type :scene
+              :root {:fx/type :v-box
+                     :children [{:fx/type :label
+                                 :text "Managed"}]}}}))

--- a/test/cljfx/lifecycle_test.clj
+++ b/test/cljfx/lifecycle_test.clj
@@ -31,3 +31,26 @@
         ^Label i-3 (fx/instance c-3)
         _ (fact (.getText i-3) => ":a 1, :b 2")
         _ (fact (= i-1 i-2 i-3) => true)]))
+
+(deftest manage-instance-test
+  (let [manage-instance (Label. "unmanaged")
+        test-manage-instance (fn [text]
+                               (fact (.getText manage-instance) => text))
+        _ (test-manage-instance "unmanaged")
+        label (fn [{:keys [id]}]
+                {:fx/type :label
+                 :fx/manage-instance manage-instance
+                 :text (str "managed " id)})
+        c-1 (fx/create-component (label {:id 1}))
+        _ (test-manage-instance "managed 1")
+        _ (fact (identical? manage-instance (fx/instance c-1)) => true)
+        c-2 (fx/advance-component c-1 (label {:id 2}))
+        _ (test-manage-instance "managed 2")
+        _ (fact (identical? manage-instance (fx/instance c-2)) => true)
+        
+        c-3 (fx/advance-component c-2 (-> (label {:id 3})
+                                          (dissoc :fx/manage-instance)))
+        ^Label i-3 (fx/instance c-3)
+        _ (test-manage-instance "managed 2")
+        _ (fact (.getText i-3) => "managed 3")
+        _ (fact (identical? manage-instance i-3) => false)]))


### PR DESCRIPTION
_Please hide whitespace changes when reviewing_

The original problem I had was implementing the [Sharing the Stage](https://docs.oracle.com/javafx/2/deployment/preloaders.htm#BABBBBBJ) tutorial, where I wanted the preloader's stage to be inherited by cljfx seamlessly.

What do you think of this kind of solution?