### PR TITLE
Bump javafx to 17.0.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,9 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.openjfx/javafx-controls {:mvn/version "17.0.0.1"}
-        org.openjfx/javafx-base {:mvn/version "17.0.0.1"}
-        org.openjfx/javafx-graphics {:mvn/version "17.0.0.1"}
-        org.openjfx/javafx-media {:mvn/version "17.0.0.1"}
-        org.openjfx/javafx-web {:mvn/version "17.0.0.1"}}
+        org.openjfx/javafx-controls {:mvn/version "17.0.2"}
+        org.openjfx/javafx-base {:mvn/version "17.0.2"}
+        org.openjfx/javafx-graphics {:mvn/version "17.0.2"}
+        org.openjfx/javafx-media {:mvn/version "17.0.2"}
+        org.openjfx/javafx-web {:mvn/version "17.0.2"}}
  :paths ["src" "jdk11"]
  :aliases {:examples {:extra-paths ["examples"]
                       :extra-deps {org.jsoup/jsoup {:mvn/version "1.11.3"}


### PR DESCRIPTION
This fixes, probably among other things, https://bugs.openjdk.java.net/browse/JDK-8275723 which makes cljfx unusable on M1, see https://github.com/vlaaad/reveal/issues/36 for example of how this affects reveal.