### PR TITLE
Add the `:user-data` prop on `Node`

### DIFF
--- a/src/cljfx/fx/node.clj
+++ b/src/cljfx/fx/node.clj
@@ -112,4 +112,5 @@
       :translate-x [:setter lifecycle/scalar :coerce double :default 0]
       :translate-y [:setter lifecycle/scalar :coerce double :default 0]
       :translate-z [:setter lifecycle/scalar :coerce double :default 0]
+      :user-data [:setter lifecycle/scalar]
       :visible [:setter lifecycle/scalar :default true])))


### PR DESCRIPTION
Previously trying to render something along the lines of...

```clj
{:fx/type :text-field
 :user-data {:roles [:search-field]}}
```

...would have resulted in: `clojure.lang.ExceptionInfo: No such prop: :user-data {:prop :user-data}`.

According to the JavaFX docs at
https://openjfx.io/javadoc/20/javafx.graphics/javafx/scene/Node.html#setUserData(java.lang.Object) `.getUserData` and `.setUserData` are available on every `Node`.

This adds the `:user-data` prop to the props definition map for `Node` so that the prop can be specified on a cljfx node description. Please see the original discussion at https://clojurians.slack.com/archives/CGHHJNENB/p1692261384256739

P.S. I would have added tests to this, yet I couldn't find any implemented for other props and I'm not sure where to start.