### PR TITLE
Fix `actions/cache` hang, bump build deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Cache Clojure deps
-        uses: actions/cache@v2
+      - uses: actions/checkout@v2
+      - name: Restore Clojure deps cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -17,16 +18,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clojure-${{ hashFiles('pom.xml') }}-
             ${{ runner.os }}-clojure-
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: '11.0.2'
+          distribution: 'zulu'
+          java-version: '11'
       - uses: DeLaGuardo/setup-clojure@3.3
         with: 
-          cli: '1.10.1.763'
-          lein: '2.9.6'
+          cli: '1.12.0.1479'
+          lein: '2.11.2'
       - name: Run tests
         run: clojure -M:test:runner:headless
       - name: Compile splash screen example
         run: |
           cd example-projects/splash
           lein uberjar
+      - name: Save Clojure deps cache
+        uses: actions/cache/save@v4
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Builds about 2.5 minutes faster. See PR on my own fork, build takes 30s: https://github.com/frenchy64/cljfx/pull/9

Related: https://github.com/actions/cache/issues/1442