### PR TITLE
A note on the render middleware

### DIFF
--- a/examples/e12_interactive_development.clj
+++ b/examples/e12_interactive_development.clj
@@ -31,6 +31,9 @@
 
 (def renderer
   (fx/create-renderer
+    ;; NOTE make sure not to reference `root-view` directly, i.e.
+    ;; :middleware (fx/wrap-map-desc assoc :fx/type root)
+    ;; Instead, wrap it in another lambda view like below.
     :middleware (fx/wrap-map-desc (fn [state]
                                     {:fx/type root-view
                                      :state state}))


### PR DESCRIPTION
Hi,

Just thought a note here will be helpful.

My code didn't work when evaluating `(renderer)` at first (after redefining the root view), because I copied the initial code from the beginning of the README. I figured out the issue here, so I created this PR.

Thanks.