### PR TITLE
Implement :check-box-tree-item and :check-box-tree-cell

### DIFF
--- a/src/cljfx/fx.clj
+++ b/src/cljfx/fx.clj
@@ -161,10 +161,12 @@
      :tool-bar (lazy-load cljfx.fx.tool-bar/lifecycle)
      :tree-table-view (lazy-load cljfx.fx.tree-table-view/lifecycle)
      :tree-item (lazy-load cljfx.fx.tree-item/lifecycle)
+     :check-box-tree-item (lazy-load cljfx.fx.check-box-tree-item/lifecycle)
      :tree-table-column (lazy-load cljfx.fx.tree-table-column/lifecycle)
      :tree-view (lazy-load cljfx.fx.tree-view/lifecycle)
      ;; cells
      :cell (lazy-load cljfx.fx.cell/lifecycle)
+     :check-box-tree-cell (lazy-load cljfx.fx.check-box-tree-cell/lifecycle)
      :date-cell (lazy-load cljfx.fx.date-cell/lifecycle)
      :indexed-cell (lazy-load cljfx.fx.indexed-cell/lifecycle)
      :list-cell (lazy-load cljfx.fx.list-cell/lifecycle)

--- a/src/cljfx/fx/check_box_tree_cell.clj
+++ b/src/cljfx/fx/check_box_tree_cell.clj
@@ -1,0 +1,58 @@
+(ns cljfx.fx.check-box-tree-cell
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.lifecycle :as lifecycle]
+            [cljfx.fx.tree-cell :as fx.tree-cell]
+            [cljfx.coerce :as coerce]
+            [cljfx.mutator :as mutator])
+  (:import [javafx.scene.control.cell CheckBoxTreeCell]
+           [javafx.scene AccessibleRole]
+           [javafx.scene.control Labeled]))
+
+(def text-key "cljfx-text")
+(def graphics-key "cljfx-graphic")
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.tree-cell/props
+    (composite/props CheckBoxTreeCell
+      ;; overrides
+      :style-class [:list lifecycle/scalar :coerce coerce/style-class
+                    :default ["cell" "indexed-cell" "tree-cell" "check-box-tree-cell"]]
+      :accessible-role [:setter lifecycle/scalar :coerce (coerce/enum AccessibleRole)
+                        :default :check-box-tree-item]
+      :text [(mutator/setter (fn [^Labeled cell x]
+                               (.setText cell x)
+                               (.put (.getProperties cell) text-key x)))
+             lifecycle/scalar
+             :default ""]
+      :graphic [(mutator/setter (fn [^Labeled cell x]
+                                  (.setGraphic cell x)
+                                  (.put (.getProperties cell) graphics-key x)))
+                lifecycle/dynamic]
+      ;; definitions
+      :converter [:setter lifecycle/scalar :coerce coerce/string-converter]
+      :selected-state-callback [:setter lifecycle/scalar])))
+
+;; proxy-super uses reflection because updateItem is protected
+
+(set! *warn-on-reflection* false)
+
+(def lifecycle
+  (lifecycle/annotate
+    (composite/lifecycle
+      {:props props
+       :args []
+       :ctor (fn []
+               (proxy [CheckBoxTreeCell] []
+                 (updateItem [item empty]
+                   (proxy-super updateItem item empty)
+                   (when (not empty)
+                     (let [props (.getProperties this)]
+                       (when-let [text (.get props text-key)]
+                         (proxy-super setText text))
+                       (when-let [graphic (.get props graphics-key)]
+                         (proxy-super setGraphic graphic)))))))})
+    :check-box-tree-cell))

--- a/src/cljfx/fx/check_box_tree_item.clj
+++ b/src/cljfx/fx/check_box_tree_item.clj
@@ -1,0 +1,24 @@
+(ns cljfx.fx.check-box-tree-item
+  "Part of a public API"
+  (:require [cljfx.composite :as composite]
+            [cljfx.fx.tree-item :as fx.tree-item]
+            [cljfx.lifecycle :as lifecycle])
+  (:import [javafx.scene.control CheckBoxTreeItem]))
+
+(set! *warn-on-reflection* true)
+
+(def props
+  (merge
+    fx.tree-item/props
+    (composite/props CheckBoxTreeItem
+      :independent [:setter lifecycle/scalar :default false]
+      :indeterminate [:setter lifecycle/scalar :default false]
+      :selected [:setter lifecycle/scalar :default false]
+      :on-selected-changed [:property-change-listener lifecycle/change-listener])))
+
+(def lifecycle
+  (lifecycle/annotate
+    (composite/describe CheckBoxTreeItem
+      :ctor []
+      :props props)
+    :check-box-tree-item))


### PR DESCRIPTION
I wanted to use [CheckBoxTreeItem](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/CheckBoxTreeItem.html) and [CheckBoxTreeCell](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/cell/CheckBoxTreeCell.html) but after finding https://github.com/cljfx/cljfx/issues/160 saw that they are not directly supported by `cljfx`. I just copied and adapted code from existing components and for my simple use case it seems to work.

Two issues that I can't get my head around:

1. The cell factory does not work as expected for me: 
(**solved** see [here](https://github.com/cljfx/cljfx/pull/194#issuecomment-4085307972))
```clojure
(ns core
  (:require [cljfx.api :as fx]))

(def test-data
 {"a" nil
  "b" nil
  "c" {"d" nil
       "e" {"f" nil
            "g" nil}}})

(defn tree-item [[name children]]
  {:fx/type :check-box-tree-item
   :expanded true
   :value {:name name}
   :children (when children
               (mapv tree-item children))})

(defn tree [{:keys [data]}]
  {:fx/type :tree-view
   :show-root false
   :cell-factory {:fx/cell-type :check-box-tree-cell
                 ;; HERE this function is called but it doesn't "work"
                  :describe (fn [n]
                              (println "I'm called!")
                              {:text (:name n)})}
   :root {:fx/type :check-box-tree-item
          :value {:name ""}
          :children (map tree-item data)}})

(fx/on-fx-thread
  (fx/create-component
    {:fx/type :stage
     :showing true
     :width 400
     :height 500
     :scene {:fx/type :scene
             :root {:fx/type :v-box
                    :padding 5
                    :children [{:fx/type tree
                                :data test-data}]}}}))
```
I would expect that the individual items only show the name and not the whole map passed to `:value`
<img width="417" height="525" alt="image" src="https://github.com/user-attachments/assets/21eb0d4d-9c6c-4784-bd01-cc5922fc4882" />

3. I don't understand how to map the [selectedStateCallback](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/cell/CheckBoxTreeCell.html#selectedStateCallbackProperty) property in [this file](https://github.com/TheBlob42/cljfx/blob/22002d46eba2ef20f2ad50d324314cf35a257051/src/cljfx/fx/check_box_tree_cell.clj#L23-L24) exactly

Also I haven't checked for test coverage, formatting or anything else yet. Just wanted to clarify my issues and then see if the PR can be made fitting for merging into `cljfx` :slightly_smiling_face: happy for any feedback